### PR TITLE
Add run_tests script, run automatically in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: python
+python:
+  - 2.7
+  - 3.2
+matrix:
+  fast_finish: true
+  allow_failures:
+    - python: 3.2
+virtualenv:
+  system_site_packages: true
+before_install:
+  - sudo apt-get install -qq python-numpy python-scipy python3-numpy python3-scipy
+install: 
+  -  LAPACK=/usr/lib/liblapack.so ATLAS=/usr/lib/libatlas.so BLAS=/usr/lib/libblas.so pip install -r requirements_for_travis.txt
+script:
+  - ./run_tests.sh
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 pytides
 =======
+[![Build Status](https://travis-ci.org/sam-cox/pytides.svg)](https://travis-ci.org/sam-cox/pytides)
 ####About
 Pytides is small Python package for the analysis and prediction of tides. Pytides can be used to extrapolate the tidal behaviour at a given location from its previous behaviour. The method used is that of harmonic constituents, in particular as presented by P. Schureman in Special Publication 98. The fitting of amplitudes and phases is handled by Scipy's leastsq minimisation function. Pytides currently supports the constituents used by NOAA, with plans to add more constituent sets. It is therefore possible to use the amplitudes and phases published by NOAA directly, without the need to perform the analysis again (although there may be slight discrepancies for some constituents).
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+-r requirements/_common.txt
+-r requirements/_numpy_and_scipy.txt

--- a/requirements/_common.txt
+++ b/requirements/_common.txt
@@ -1,0 +1,1 @@
+# any other requirements in here

--- a/requirements/_numpy_and_scipy.txt
+++ b/requirements/_numpy_and_scipy.txt
@@ -1,0 +1,5 @@
+# These are broken out because Travis CI needs to use the system-wide packages
+# rather than installing them into the virtualenv.
+
+scipy==0.14.0
+numpy==1.8.1

--- a/requirements_for_travis.txt
+++ b/requirements_for_travis.txt
@@ -1,0 +1,5 @@
+-r requirements/_common.txt
+
+nose==1.3.3
+flake8==2.1.0
+pyflakes==0.8.1

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+
+function run_pep8_style_checks {
+    flake8 .
+}
+
+
+function run_python_unit_tests {
+    nosetests
+}
+
+# run_pep8_style_checks  # disabled until PEP8 changes are merged
+run_python_unit_tests


### PR DESCRIPTION
Add a test runner script which tests for PEP8 and runs any units tests
using nosetests (there currently aren't any).

This will run on Travis CI after visiting https://travis-ci.org/profile and
enabling it for the repo.
