### PR TITLE
Using `from __future__ import absolute_import`, and `from functools impo...

### DIFF
--- a/pytides/__init__.py
+++ b/pytides/__init__.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 
-import tide
-import astro
-import constituent
-import nodal_corrections
+from __future__ import absolute_import
+from pytides import tide
+from pytides import astro
+from pytides import constituent
+from pytides import nodal_corrections
 

--- a/pytides/constituent.py
+++ b/pytides/constituent.py
@@ -2,7 +2,8 @@
 import string
 import operator as op
 import numpy as np
-import nodal_corrections as nc
+from . import nodal_corrections as nc
+from functools import reduce
 
 class BaseConstituent(object):
 	xdo_int = {

--- a/pytides/tide.py
+++ b/pytides/tide.py
@@ -9,8 +9,8 @@ except ImportError: #Python3
 from datetime import datetime, timedelta
 import numpy as np
 from scipy.optimize import leastsq, fsolve
-from astro import astro
-import constituent
+from .astro import astro
+from . import constituent
 
 d2r, r2d = np.pi/180.0, 180.0/np.pi
 


### PR DESCRIPTION
Using `from __future__ import absolute_import`, and `from functools import reduce` to improve py3k compatibility.
