### PR TITLE
Fix typo

### DIFF
--- a/pytides/constituent.py
+++ b/pytides/constituent.py
@@ -27,7 +27,7 @@ class BaseConstituent(object):
 		return [self.xdo_int[l.upper()] for l in xdo if l in string.ascii_letters]
 
 	def coefficients_to_xdo(self, coefficients):
-		return ''.join([self.int_xdo[c] for c in cooefficients])
+		return ''.join([self.int_xdo[c] for c in coefficients])
 
 	def V(self, astro):
 		return np.dot(self.coefficients, self.astro_values(astro))


### PR DESCRIPTION
I was experimenting to understand the constituent functions with the code below and discovered the coefficients-cooefficients typo.

```
zzzz = pytides.constituent.noaa[0]

print("constituent.noaa[0]: ",zzzz)

a = pytides.astro.astro(datetime.datetime.utcnow())
#print(a) # astronomical parameters at time 'a'

print("...name",zzzz.name)
print("...coefficients",zzzz.coefficients)
#print("...xdo()",zzzz.xdo())  # error!!! NameError: name 'cooefficients' is not defined

# time dependent constituent functions:
print("...speed(a)",zzzz.speed(a))
print("...V(a)",zzzz.V(a))
print("...astro_xdo(a)",zzzz.astro_xdo(a))
print("...astro_speeds(a)",zzzz.astro_speeds(a))
print("...astro_values(a)",zzzz.astro_values(a))
print("...speed(a)",zzzz.speed(a))
print("...speed(a)",zzzz.speed(a))
print("...u()",zzzz.u(a))
print("...f()",zzzz.f(a))
```