### PR TITLE
Fixed deprecated np.float issue by replacing with float to ensure com…

### DIFF
--- a/pytides/tide.py
+++ b/pytides/tide.py
@@ -235,7 +235,7 @@ class Tide(object):
 		"""
 		partition = float(partition)
 		relative = hours - hours[0]
-		total_partitions = np.ceil(relative[-1] / partition + 10*np.finfo(np.float).eps).astype('int')
+		total_partitions = np.ceil(relative[-1] / partition + 10*np.finfo(float).eps).astype('int')
 		return [hours[np.floor(np.divide(relative, partition)) == i] for i in range(total_partitions)]
 
 	@staticmethod


### PR DESCRIPTION
…patibility with latest NumPy versions.

NumPy 1.20 (release notes) deprecated numpy.float, numpy.int, and similar aliases, causing them to issue a deprecation warning

NumPy 1.24 (release notes) removed these aliases altogether, causing an error when they are used

For more details, follow the link:

https://stackoverflow.com/questions/74844262/how-can-i-solve-error-module-numpy-has-no-attribute-float-in-python